### PR TITLE
IMU 데이터를 받아옴 + 선형보간법으로 정확한(?) 회전

### DIFF
--- a/src/data_integrate/include/data_integrate/features/visible_feature_manager.h
+++ b/src/data_integrate/include/data_integrate/features/visible_feature_manager.h
@@ -2,6 +2,8 @@
 #define DATA_INTEGRATE_FEATURES_VISIBLE_FEATURE_MANAGER_H
 
 #include <core_msgs/ball_position.h>
+#include <geometry_msgs/Vector3.h>
+#include <sensor_msgs/Imu.h>
 #include <sensor_msgs/LaserScan.h>
 #include <vector>
 #include "./ball.h"
@@ -29,6 +31,13 @@ public:
 
   using BallCollection = std::vector<Ball>;
   using LidarPointCollection = std::vector<RelPoint>;
+
+  /**
+   * IMU topic에 subscribe하여 데이터를 받기 위한 callback입니다.
+   *
+   * @param msg topic으로부터 받는 데이터 메시지
+   */
+  void subscribeToImu(const sensor_msgs::Imu::ConstPtr& msg);
 
   /**
    * 가장 최근에 카메라로 관측한 공의 목록을 가져옵니다.
@@ -61,6 +70,24 @@ public:
    */
   void addBall(const Ball& ball);
 
+  using ImuVectorT = geometry_msgs::Vector3;
+
+  /**
+   * @returns IMU로 가장 최근에 측정한 각속도 벡터 (rad/s)
+   */
+  const ImuVectorT& getImuAngularVelocity() const
+  {
+    return imu_angular_velocity_;
+  }
+
+  /**
+   * @returns IMU로 가장 최근에 측정한 선가속도 벡터 (m/s^2)
+   */
+  const ImuVectorT& getImuLinearAcceleration() const
+  {
+    return imu_linear_acceleration_;
+  }
+
   /**
    * 기억 중인 모든 feature 정보를 지웁니다.
    */
@@ -70,6 +97,8 @@ private:
   BallCollection balls_;
   LidarPointCollection lidar_points_;
   bool is_blue_ball_captured_ = false;
+  ImuVectorT imu_angular_velocity_;     ///< (x축, y축, z축) (rad/s)
+  ImuVectorT imu_linear_acceleration_;  ///< (x, y, z) (m/s^2)
 };
 
 #endif  // DATA_INTEGRATE_FEATURES_VISIBLE_FEATURE_MANAGER_H

--- a/src/data_integrate/include/data_integrate/simple_wheel_controller.h
+++ b/src/data_integrate/include/data_integrate/simple_wheel_controller.h
@@ -61,6 +61,14 @@ public:
    */
   void publish() const;
 
+  /**
+   * 로봇이 제자리에서 일정한 각속도로 회전하기 위해 각 바퀴에 전달해야 하는 속도 신호값을 계산합니다.
+   *
+   * @param robot_angular_velocity  로봇의 반시계 방향 회전 속도 (rad/s). 0보다 작으면 시계 방향의 회전 속도입니다.
+   * @returns 우측 바퀴에 전달할 속도 신호값. 좌측 바퀴에는 이 값과 크기는 같고 부호가 반대인 신호값을 전달해야 합니다.
+   */
+  static double convertRobotAngularVelocityToWheelVelocity(double angular_velocity);
+
 private:
   double linear_speed_ = 0;
   double angular_speed_ = 0;

--- a/src/data_integrate/src/blackboard.cpp
+++ b/src/data_integrate/src/blackboard.cpp
@@ -10,6 +10,5 @@ double Blackboard::getRobotLinearSpeed() const
 
 double Blackboard::getRobotAngularSpeed() const
 {
-  // TODO: 진짜 각속도를 구해야 함
-  return wheel_controller_.getAngularSpeed();
+  return visible_features_.getImuAngularVelocity().z;
 }

--- a/src/data_integrate/src/data_integration.cpp
+++ b/src/data_integrate/src/data_integration.cpp
@@ -1,5 +1,6 @@
 #include <core_msgs/ball_position.h>
 #include <ros/ros.h>
+#include <sensor_msgs/Imu.h>
 #include <sensor_msgs/LaserScan.h>
 #include <std_msgs/Float64.h>
 
@@ -20,6 +21,8 @@ int main(int argc, char** argv)
   ros::Subscriber sub_ball_harvest = n.subscribe<core_msgs::ball_position>(
       "/position", 1000, &VisibleFeatureManager::subscribeToCamera, &visible_features);
   // ros::Subscriber sub_line_tracing = n.subscribe<core_msgs::line_info>("/line_info", 1000, camera_Callback_2);
+  ros::Subscriber sub_imu =
+      n.subscribe<sensor_msgs::Imu>("/imu", 1000, &VisibleFeatureManager::subscribeToImu, &visible_features);
 
   ros::Publisher fl_wheel = n.advertise<std_msgs::Float64>("/myrobot/FLwheel_velocity_controller/command", 10);
   ros::Publisher fr_wheel = n.advertise<std_msgs::Float64>("/myrobot/FRwheel_velocity_controller/command", 10);

--- a/src/data_integrate/src/features/visible_feature_manager.cpp
+++ b/src/data_integrate/src/features/visible_feature_manager.cpp
@@ -65,3 +65,10 @@ void VisibleFeatureManager::clearAllFeatures()
   balls_.clear();
   lidar_points_.clear();
 }
+
+void VisibleFeatureManager::subscribeToImu(const sensor_msgs::Imu::ConstPtr& msg)
+{
+  // 주의: 창시구 규정에 의해 orientation은 사용 금지됨
+  imu_angular_velocity_ = msg->angular_velocity;
+  imu_linear_acceleration_ = msg->linear_acceleration;
+}

--- a/src/data_integrate/src/simple_wheel_controller.cpp
+++ b/src/data_integrate/src/simple_wheel_controller.cpp
@@ -1,8 +1,13 @@
 #include "data_integrate/simple_wheel_controller.h"
 
+#include <ros/ros.h>
 #include <std_msgs/Float64.h>
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+#include <utility>
 
-SimpleWheelController::SimpleWheelController(const ros::Publisher &left_wheel, const ros::Publisher &right_wheel)
+SimpleWheelController::SimpleWheelController(const ros::Publisher& left_wheel, const ros::Publisher& right_wheel)
   : left_wheel_(left_wheel), right_wheel_(right_wheel)
 {
 }
@@ -32,11 +37,67 @@ void SimpleWheelController::publish() const
 
   // TODO: 올바른 계수를 직접 계산하거나 실험적으로 구해야 함
   const double LINEAR_SPEED_FACTOR = 1;
-  const double ANGULAR_SPEED_FACTOR = 1;
+  auto wheel_angular_speed = convertRobotAngularVelocityToWheelVelocity(angular_speed_);
 
-  left_wheel_msg.data = LINEAR_SPEED_FACTOR * linear_speed_ - ANGULAR_SPEED_FACTOR * angular_speed_;
-  right_wheel_msg.data = LINEAR_SPEED_FACTOR * linear_speed_ + ANGULAR_SPEED_FACTOR * angular_speed_;
+  left_wheel_msg.data = LINEAR_SPEED_FACTOR * linear_speed_ - wheel_angular_speed;
+  right_wheel_msg.data = LINEAR_SPEED_FACTOR * linear_speed_ + wheel_angular_speed;
 
   left_wheel_.publish(left_wheel_msg);
   right_wheel_.publish(right_wheel_msg);
+}
+
+using InterPoint = std::pair<double, double>;
+
+/**
+ * 선형보간법에 사용할 기준점의 목록입니다.
+ * 각 항목은 { 로봇의 각속도, 바퀴의 각속도 }의 쌍이며, 실험적으로 구한 것입니다.
+ *
+ * 주의사항:
+ *  - 이 배열은 크기순으로 정렬되어 있어야 합니다.
+ *  - 첫 값은 항상 (0, 0)이어야 합니다.
+ *  - 중복되는 값이 없어야 합니다.
+ */
+const InterPoint ROBOT_TO_WHEEL_ANGULAR[] = {
+  { 0, 0 },
+  { 0.31573, 1.30900 },
+  { 0.80468, 2.61799 },
+  { 1.29654, 3.92699 },
+  { 1.80750, 5.23599 },
+  { 2.31900, 6.54499 },
+  { 2.57867, 7.85398 },
+};
+
+double SimpleWheelController::convertRobotAngularVelocityToWheelVelocity(double robot_angular_velocity)
+{
+  auto robot_angular_speed = std::abs(robot_angular_velocity);
+
+  // 이진 탐색(binary search)으로 목표한 속도값의 양쪽에 있는 기준점 a, b를 찾는다
+  auto r2w_begin = std::begin(ROBOT_TO_WHEEL_ANGULAR);
+  auto r2w_end = std::end(ROBOT_TO_WHEEL_ANGULAR);
+  InterPoint search_target(robot_angular_speed, 0);
+  auto b = std::lower_bound(r2w_begin, r2w_end, search_target,
+                            [=](const InterPoint& p, const InterPoint& q) { return p.first < q.first; });
+
+  if (r2w_begin == b)
+  {
+    // 속력이 0인 경우
+    return 0;
+  }
+  ROS_ASSERT_MSG(b < r2w_end, "Robot angular speed is too large to convert: %f", robot_angular_velocity);
+  auto a = b - 1;
+
+  // 선형 보간(linear interpolation)으로 바퀴의 각속력을 구한다
+  auto a_robot = a->first, a_wheel = a->second;
+  auto b_robot = b->first, b_wheel = b->second;
+  ROS_ASSERT_MSG(a_wheel != b_wheel, "Duplicate entry in ROBOT_TO_WHEEL_ANGULAR: %f", a_wheel);
+  auto wheel_speed = (robot_angular_speed - a_robot) / (b_robot - a_robot) * (b_wheel - a_wheel) + a_wheel;
+
+  if (robot_angular_velocity >= 0)
+  {
+    return wheel_speed;
+  }
+  else
+  {
+    return -wheel_speed;
+  }
 }


### PR DESCRIPTION
VisibleFeatureManager가 IMU로부터 선가속도+각속도 정보를 받아오게 만들었습니다. 이제 Blackboard에서 로봇의 현재 각속도를 제공할 때 바퀴에 보낸 신호값이 아니라 IMU에서 받은 데이터를 사용합니다.

또한 이를 바탕으로 다양한 회전 속도값을 테스트하여, SimpleWheelController가 선형보간법으로 로봇 각속도 <-> 바퀴 각속도를 변환함으로서 원하는 각도만큼 더 정확하게 회전할 수 있게 만들었습니다.

(그런데 실제 테스트해 본 결과 좌회전 후 우회전을 할 때 첫 좌회전이 너무 멀리 나가는 문제가 있습니다...어떻게 하면 좋을지...ㅜ)
회전 운동을 시작하거나 종료할 때의 가속도를 고려하지 않기 때문에 overshoot하는 것 같습니다.

속도값 실험 결과는 https://docs.google.com/spreadsheets/d/1rAeQssF7j-nt9rG-pN0XrIPGCbyHwRBS/edit#gid=1914214344 에서 확인할 수 있습니다.